### PR TITLE
add deploy steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Deploy Gatsby to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Build Gatsby
+        run: make build
+        env:
+          PREFIX_PATHS: true
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './public'  # Gatsbyのビルド出力ディレクトリ
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of a Gatsby site to GitHub Pages. The main changes include setting up the workflow to trigger on specific events, configuring permissions, and defining the deployment steps.

### GitHub Actions Workflow for Deployment:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R51): Added a new workflow named "Deploy Gatsby to GitHub Pages" that triggers on pushes to the `main` branch and manual dispatch. It includes steps for checking out the repository, setting up Node.js, installing dependencies, building the Gatsby site, configuring Pages, uploading the build artifact, and deploying to GitHub Pages.