### PR TITLE
add run server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,5 @@ EXPOSE 8000
 ENV GATSBY_HOST=0.0.0.0
 
 # Start the development server
-CMD ["sh", "-c", "cd src && npm run develop"]
+WORKDIR /app/src
+CMD ["npm", "run", "develop"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,6 @@ EXPOSE 8000
 
 # Set host to allow external connections
 ENV GATSBY_HOST=0.0.0.0
+
+# Start the development server
+CMD ["sh", "-c", "cd src && npm run develop"]


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change adds a command to start the development server.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R37-R39): Added `CMD` instruction to start the development server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the development environment by adding a command to start the development server within the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->